### PR TITLE
feat(ci): Add GitHub Action to build and publish OCI image to GHCR on tag release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,32 @@
+name: Publish Container
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+    
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository  }}:${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to build and publish an OCI container
image to GitHub Container Registry (ghcr.io) on tagged releases.

## Details

- Triggered on `v*` tags
- Logs in to GHCR using `GITHUB_TOKEN`
- Builds Docker image from root Dockerfile
- Tags image using the git tag (e.g., v1.2.3)
- Pushes image to ghcr.io/<owner>/cyclonedx-bom-studio

This enables automated container publishing for releases.