### PR TITLE
fix(ui): version range example

### DIFF
--- a/src/i18n/locales/ar-SA.json
+++ b/src/i18n/locales/ar-SA.json
@@ -137,7 +137,7 @@
     "mimeTypePlaceholder": "مثال: application/json",
     "versionOr": "أو",
     "versionRange": "نطاق الإصدار",
-    "versionRangePlaceholder": "مثال: >=1.0.0 <2.0.0",
+    "versionRangePlaceholder": "مثال: vers:npm/1.2.3|>=2.0.0|<5.0.0",
     "isExternal": "مكون خارجي",
     "tags": "الوسوم",
     "tagsPlaceholder": "أدخل وسمًا واضغط Enter",

--- a/src/i18n/locales/de-DE.json
+++ b/src/i18n/locales/de-DE.json
@@ -137,7 +137,7 @@
     "mimeTypePlaceholder": "z.B. application/json",
     "versionOr": "oder",
     "versionRange": "Versionsbereich",
-    "versionRangePlaceholder": "z.B. >=1.0.0 <2.0.0",
+    "versionRangePlaceholder": "z.B. vers:npm/1.2.3|>=2.0.0|<5.0.0",
     "isExternal": "Externe Komponente",
     "tags": "Tags",
     "tagsPlaceholder": "Tag eingeben und Enter drücken",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -135,7 +135,7 @@
     "mimeTypePlaceholder": "e.g. application/json",
     "versionOr": "or",
     "versionRange": "Version Range",
-    "versionRangePlaceholder": "e.g. >=1.0.0 <2.0.0",
+    "versionRangePlaceholder": "e.g. vers:npm/1.2.3|>=2.0.0|<5.0.0",
     "isExternal": "External Component",
     "tags": "Tags",
     "tagsPlaceholder": "Enter tag and press Enter",

--- a/src/i18n/locales/es-ES.json
+++ b/src/i18n/locales/es-ES.json
@@ -137,7 +137,7 @@
     "mimeTypePlaceholder": "ej. application/json",
     "versionOr": "o",
     "versionRange": "Rango de versiones",
-    "versionRangePlaceholder": "ej. >=1.0.0 <2.0.0",
+    "versionRangePlaceholder": "ej. vers:npm/1.2.3|>=2.0.0|<5.0.0",
     "isExternal": "Componente externo",
     "tags": "Etiquetas",
     "tagsPlaceholder": "Ingrese una etiqueta y presione Enter",

--- a/src/i18n/locales/fr-FR.json
+++ b/src/i18n/locales/fr-FR.json
@@ -137,7 +137,7 @@
     "mimeTypePlaceholder": "ex. application/json",
     "versionOr": "ou",
     "versionRange": "Plage de versions",
-    "versionRangePlaceholder": "ex. >=1.0.0 <2.0.0",
+    "versionRangePlaceholder": "ex. vers:npm/1.2.3|>=2.0.0|<5.0.0",
     "isExternal": "Composant externe",
     "tags": "Étiquettes",
     "tagsPlaceholder": "Entrer une étiquette et appuyer sur Entrée",

--- a/src/i18n/locales/ja-JP.json
+++ b/src/i18n/locales/ja-JP.json
@@ -137,7 +137,7 @@
     "mimeTypePlaceholder": "例: application/json",
     "versionOr": "または",
     "versionRange": "バージョン範囲",
-    "versionRangePlaceholder": "例: >=1.0.0 <2.0.0",
+    "versionRangePlaceholder": "例: vers:npm/1.2.3|>=2.0.0|<5.0.0",
     "isExternal": "外部コンポーネント",
     "tags": "タグ",
     "tagsPlaceholder": "タグを入力してEnterを押してください",

--- a/src/i18n/locales/ru-RU.json
+++ b/src/i18n/locales/ru-RU.json
@@ -137,7 +137,7 @@
     "mimeTypePlaceholder": "напр. application/json",
     "versionOr": "или",
     "versionRange": "Диапазон версий",
-    "versionRangePlaceholder": "напр. >=1.0.0 <2.0.0",
+    "versionRangePlaceholder": "напр. vers:npm/1.2.3|>=2.0.0|<5.0.0",
     "isExternal": "Внешний компонент",
     "tags": "Теги",
     "tagsPlaceholder": "Введите тег и нажмите Enter",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -137,7 +137,7 @@
     "mimeTypePlaceholder": "例如 application/json",
     "versionOr": "或",
     "versionRange": "版本范围",
-    "versionRangePlaceholder": "例如 >=1.0.0 <2.0.0",
+    "versionRangePlaceholder": "例如 vers:npm/1.2.3|>=2.0.0|<5.0.0",
     "isExternal": "外部组件",
     "tags": "标签",
     "tagsPlaceholder": "输入标签并按回车",


### PR DESCRIPTION
CycloneDX spec for vereison range - <https://cyclonedx.org/docs/1.7/json/#metadata_tools_oneOf_i0_components_items_versionRange>
> [...] The value must adhere to the Package URL Version Range syntax (vers) [...]

The curent examples do not adhere to the spec.

The new examples do - they are taken from the official VERS spec. see https://github.com/package-url/vers-spec/blob/01e2ef47b8177efade6bcd69a007f89d1d158027/docs/standard/specification.md?plain=1#L25-L27